### PR TITLE
Fix settings page and persistent sidebar

### DIFF
--- a/Sources/HotkeyLauncher/Stores/ShortcutStore.swift
+++ b/Sources/HotkeyLauncher/Stores/ShortcutStore.swift
@@ -8,6 +8,7 @@ final class ShortcutStore: ObservableObject {
     @Published private(set) var shortcuts: [HotkeyShortcut]
     @Published private(set) var statuses: [UUID: ShortcutStatus] = [:]
     @Published var selectedID: UUID?
+    @Published var isShowingSettings = false
     @Published var launchAtLogin: Bool
     @Published var opensNewWindowWhenNoVisibleWindows: Bool
     @Published var alert: AlertItem?
@@ -50,10 +51,23 @@ final class ShortcutStore: ObservableObject {
     }
 
     var selectedShortcut: HotkeyShortcut? {
+        guard !isShowingSettings else {
+            return nil
+        }
+
         guard let selectedID else {
             return nil
         }
         return shortcuts.first(where: { $0.id == selectedID })
+    }
+
+    func selectShortcut(id: UUID) {
+        selectedID = id
+        isShowingSettings = false
+    }
+
+    func showSettings() {
+        isShowingSettings = true
     }
 
     func shortcut(id: UUID) -> HotkeyShortcut? {
@@ -135,6 +149,7 @@ final class ShortcutStore: ObservableObject {
 
         shortcuts.append(shortcut)
         selectedID = shortcut.id
+        isShowingSettings = false
         persist()
         refreshRegistrations()
     }

--- a/Sources/HotkeyLauncher/Views/ContentView.swift
+++ b/Sources/HotkeyLauncher/Views/ContentView.swift
@@ -4,56 +4,19 @@ struct ContentView: View {
     @EnvironmentObject private var store: ShortcutStore
 
     var body: some View {
-        NavigationSplitView {
+        HStack(spacing: 0) {
             SidebarView()
                 .environmentObject(store)
-                .navigationSplitViewColumnWidth(min: 260, ideal: 300)
-        } detail: {
-            if let shortcut = store.selectedShortcut {
-                ShortcutDetailView(
-                    shortcut: binding(for: shortcut),
-                    status: store.status(for: shortcut.id),
-                    launchAtLogin: Binding(
-                        get: { store.launchAtLogin },
-                        set: { store.setLaunchAtLogin($0) }
-                    ),
-                    opensNewWindowWhenNoVisibleWindows: Binding(
-                        get: { store.opensNewWindowWhenNoVisibleWindows },
-                        set: { store.setOpensNewWindowWhenNoVisibleWindows($0) }
-                    ),
-                    onChooseApplication: {
-                        store.chooseApplication(for: shortcut.id)
-                    },
-                    onOpen: {
-                        store.openShortcut(id: shortcut.id)
-                    },
-                    onRecordingChanged: { active in
-                        store.setRecordingActive(active)
-                    }
-                )
-                .id(shortcut.id)
-            } else {
-                EmptyStateView {
-                    store.addApplicationFromPanel()
-                }
-            }
-        }
-        .toolbar {
-            ToolbarItemGroup {
-                Button {
-                    store.addApplicationFromPanel()
-                } label: {
-                    Label("Add", systemImage: "plus")
-                }
+                .frame(width: 300)
+                .frame(maxHeight: .infinity)
+                .background(.regularMaterial)
 
-                Button {
-                    store.removeSelectedShortcut()
-                } label: {
-                    Label("Remove", systemImage: "minus")
-                }
-                .disabled(store.selectedShortcut == nil)
-            }
+            Divider()
+
+            detail
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .frame(minWidth: 840, minHeight: 540)
         .alert(item: $store.alert) { alert in
             Alert(
                 title: Text(alert.title),
@@ -63,6 +26,56 @@ struct ContentView: View {
         }
         .onAppear {
             store.start()
+        }
+    }
+
+    @ViewBuilder
+    private var detail: some View {
+        if store.isShowingSettings {
+            SettingsView(
+                launchAtLogin: Binding(
+                    get: { store.launchAtLogin },
+                    set: { store.setLaunchAtLogin($0) }
+                ),
+                opensNewWindowWhenNoVisibleWindows: Binding(
+                    get: { store.opensNewWindowWhenNoVisibleWindows },
+                    set: { store.setOpensNewWindowWhenNoVisibleWindows($0) }
+                ),
+                latestUpdate: store.latestUpdate,
+                isCheckingForUpdates: store.isCheckingForUpdates,
+                isDownloadingUpdate: store.isDownloadingUpdate,
+                onImport: {
+                    store.importConfiguration()
+                },
+                onExport: {
+                    store.exportConfiguration()
+                },
+                onCheckForUpdates: {
+                    store.checkForUpdates()
+                },
+                onDownloadUpdate: {
+                    store.downloadLatestUpdate()
+                }
+            )
+        } else if let shortcut = store.selectedShortcut {
+            ShortcutDetailView(
+                shortcut: binding(for: shortcut),
+                status: store.status(for: shortcut.id),
+                onChooseApplication: {
+                    store.chooseApplication(for: shortcut.id)
+                },
+                onOpen: {
+                    store.openShortcut(id: shortcut.id)
+                },
+                onRecordingChanged: { active in
+                    store.setRecordingActive(active)
+                }
+            )
+            .id(shortcut.id)
+        } else {
+            EmptyStateView {
+                store.addApplicationFromPanel()
+            }
         }
     }
 

--- a/Sources/HotkeyLauncher/Views/SettingsView.swift
+++ b/Sources/HotkeyLauncher/Views/SettingsView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Binding var launchAtLogin: Bool
+    @Binding var opensNewWindowWhenNoVisibleWindows: Bool
+
+    let latestUpdate: UpdateInfo?
+    let isCheckingForUpdates: Bool
+    let isDownloadingUpdate: Bool
+    let onImport: () -> Void
+    let onExport: () -> Void
+    let onCheckForUpdates: () -> Void
+    let onDownloadUpdate: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+
+                settingsSection("General") {
+                    Toggle("Launch at Login", isOn: $launchAtLogin)
+                        .toggleStyle(.switch)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Toggle("New window when none are visible", isOn: $opensNewWindowWhenNoVisibleWindows)
+                            .toggleStyle(.switch)
+
+                        Text("Applies to all shortcuts. When the target app is already running with no visible windows, HotkeyLauncher activates it and sends Command+N.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                settingsSection("Configuration") {
+                    HStack(spacing: 10) {
+                        Button {
+                            onImport()
+                        } label: {
+                            Label("Import", systemImage: "square.and.arrow.down")
+                        }
+
+                        Button {
+                            onExport()
+                        } label: {
+                            Label("Export", systemImage: "square.and.arrow.up")
+                        }
+                    }
+
+                    Text("Import or export shortcuts and global settings as a JSON package.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                settingsSection("Updates") {
+                    AboutUpdateView(
+                        latestUpdate: latestUpdate,
+                        isCheckingForUpdates: isCheckingForUpdates,
+                        isDownloadingUpdate: isDownloadingUpdate,
+                        onCheckForUpdates: onCheckForUpdates,
+                        onDownloadUpdate: onDownloadUpdate
+                    )
+                }
+            }
+            .padding(28)
+            .frame(maxWidth: 720, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Settings")
+                .font(.largeTitle)
+                .fontWeight(.semibold)
+
+            Text("Manage app-level behavior, configuration files, and updates.")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func settingsSection<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 12) {
+                content()
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.background)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(.separator, lineWidth: 1)
+            }
+        }
+    }
+}

--- a/Sources/HotkeyLauncher/Views/ShortcutDetailView.swift
+++ b/Sources/HotkeyLauncher/Views/ShortcutDetailView.swift
@@ -4,8 +4,6 @@ struct ShortcutDetailView: View {
     @Binding var shortcut: HotkeyShortcut
 
     let status: ShortcutStatus
-    @Binding var launchAtLogin: Bool
-    @Binding var opensNewWindowWhenNoVisibleWindows: Bool
     let onChooseApplication: () -> Void
     let onOpen: () -> Void
     let onRecordingChanged: (Bool) -> Void
@@ -60,28 +58,6 @@ struct ShortcutDetailView: View {
 
                             StatusBadge(status: status)
                         }
-                    }
-
-                    GridRow {
-                        Text("Startup")
-                            .foregroundStyle(.secondary)
-                        Toggle("Launch at Login", isOn: $launchAtLogin)
-                            .toggleStyle(.switch)
-                    }
-
-                    GridRow {
-                        Text("Windows")
-                            .foregroundStyle(.secondary)
-                        VStack(alignment: .leading, spacing: 4) {
-                            Toggle("New window when none are visible", isOn: $opensNewWindowWhenNoVisibleWindows)
-                                .toggleStyle(.switch)
-
-                            Text("Applies to all shortcuts. When the app is already running with no visible windows, Hotkey Launcher activates it and sends Command+N.")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                        .frame(maxWidth: 420, alignment: .leading)
                     }
                 }
                 .gridColumnAlignment(.leading)

--- a/Sources/HotkeyLauncher/Views/SidebarView.swift
+++ b/Sources/HotkeyLauncher/Views/SidebarView.swift
@@ -5,13 +5,18 @@ struct SidebarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            List(selection: $store.selectedID) {
+            List {
                 ForEach(store.shortcuts) { shortcut in
-                    ShortcutRowView(
-                        shortcut: shortcut,
-                        status: store.status(for: shortcut.id)
-                    )
-                    .tag(shortcut.id)
+                    Button {
+                        store.selectShortcut(id: shortcut.id)
+                    } label: {
+                        ShortcutRowView(
+                            shortcut: shortcut,
+                            status: store.status(for: shortcut.id)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .listRowBackground(selectionBackground(for: shortcut.id))
                 }
             }
             .listStyle(.sidebar)
@@ -38,37 +43,24 @@ struct SidebarView: View {
 
             Divider()
 
-            HStack(spacing: 8) {
-                Button {
-                    store.importConfiguration()
-                } label: {
-                    Label("Import", systemImage: "square.and.arrow.down")
-                }
-
-                Button {
-                    store.exportConfiguration()
-                } label: {
-                    Label("Export", systemImage: "square.and.arrow.up")
-                }
-
-                Spacer()
+            Button {
+                store.showSettings()
+            } label: {
+                Label("Settings", systemImage: "gearshape")
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
+            .buttonStyle(.plain)
+            .padding(10)
+            .background(store.isShowingSettings ? Color.accentColor.opacity(0.16) : Color.clear)
+        }
+    }
 
-            Divider()
-
-            AboutUpdateView(
-                latestUpdate: store.latestUpdate,
-                isCheckingForUpdates: store.isCheckingForUpdates,
-                isDownloadingUpdate: store.isDownloadingUpdate,
-                onCheckForUpdates: {
-                    store.checkForUpdates()
-                },
-                onDownloadUpdate: {
-                    store.downloadLatestUpdate()
-                }
-            )
+    @ViewBuilder
+    private func selectionBackground(for shortcutID: UUID) -> some View {
+        if store.selectedID == shortcutID && !store.isShowingSettings {
+            Color.accentColor.opacity(0.16)
+        } else {
+            Color.clear
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace the collapsible `NavigationSplitView` with a fixed sidebar/detail layout so the left shortcut list stays visible.
- Remove the top toolbar Add/Remove controls.
- Add a dedicated Settings page for launch-at-login, window behavior, import/export, and update controls.

## Verification
- `swift build`

Closes #2
