### PR TITLE
Keep HotkeyLauncher as menu-bar accessory

### DIFF
--- a/Sources/HotkeyLauncher/App/AppDelegate.swift
+++ b/Sources/HotkeyLauncher/App/AppDelegate.swift
@@ -8,7 +8,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        NSApp.setActivationPolicy(.regular)
+        // Keep accessory policy so LSUIElement / menu-bar-only behavior is preserved:
+        // no Dock icon, no Command+Tab entry. Windows can still be shown while accessory.
+        NSApp.setActivationPolicy(.accessory)
         store.start()
         createWindow()
         createStatusItem()
@@ -26,6 +28,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc private func showWindow() {
         if window == nil {
             createWindow()
+        }
+
+        // Never promote to `.regular` when showing UI — accessory apps can own windows.
+        if NSApp.activationPolicy() != .accessory {
+            NSApp.setActivationPolicy(.accessory)
         }
 
         window?.makeKeyAndOrderFront(nil)

--- a/Sources/HotkeyLauncher/HotkeyLauncherMain.swift
+++ b/Sources/HotkeyLauncher/HotkeyLauncherMain.swift
@@ -5,6 +5,8 @@ struct HotkeyLauncherMain {
     @MainActor
     static func main() {
         let application = NSApplication.shared
+        // Apply early so launch never briefly registers as a foreground Dock app.
+        application.setActivationPolicy(.accessory)
         let appDelegate = AppDelegate()
         application.delegate = appDelegate
         application.run()

--- a/Sources/HotkeyLauncher/Support/WindowActivator.swift
+++ b/Sources/HotkeyLauncher/Support/WindowActivator.swift
@@ -3,9 +3,14 @@ import Foundation
 
 @MainActor
 enum WindowActivator {
+    /// Brings the settings/main window forward without switching to `.regular`,
+    /// so the app stays out of the Dock and Command+Tab switcher.
     static func activateSoon() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            NSApp.setActivationPolicy(.regular)
+            if NSApp.activationPolicy() != .accessory {
+                NSApp.setActivationPolicy(.accessory)
+            }
+
             NSApp.activate(ignoringOtherApps: true)
 
             if let window = NSApp.windows.first(where: { $0.canBecomeMain }) {

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -58,6 +58,8 @@ cat >"$INFO_PLIST" <<PLIST
   <string>$BUILD_NUMBER</string>
   <key>LSMinimumSystemVersion</key>
   <string>$MIN_SYSTEM_VERSION</string>
+  <key>LSUIElement</key>
+  <true/>
   <key>NSHighResolutionCapable</key>
   <true/>
   <key>NSPrincipalClass</key>


### PR DESCRIPTION
## Summary
- Keep `NSApplication` activation policy at `.accessory` instead of promoting to `.regular` at launch or when showing windows.
- Ensure local Release Info.plist generation includes `LSUIElement=true` in `script/build_and_run.sh`.
- Preserve menu bar, settings window, Launch at Login, and global hotkey behavior while removing Dock / Command+Tab presence.

Note: A matching `LSUIElement=true` addition for `.github/workflows/release.yml` is recommended for CI Release builds; runtime `.accessory` policy already fixes Dock / App Switcher behavior even without that plist key.

## Test plan
- [ ] Build Release and replace `/Applications/HotkeyLauncher.app`
- [ ] `lsappinfo info -app "Hotkey Launcher"` shows `type="UIElement"` (not Foreground)
- [ ] No Dock icon and no Command+Tab entry
- [ ] Menu bar icon works; Open Hotkey Launcher / Settings still usable
- [ ] Ctrl+Option+S launches/switches Sublime Text from Finder, Cursor, Safari
- [ ] Launch at Login still starts the app in the background


Made with [Cursor](https://cursor.com)